### PR TITLE
feat: prod 환경 CloudWatch 로그 연동 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,6 +40,8 @@ dependencies {
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
 	implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")
 	implementation("tools.jackson.module:jackson-module-kotlin")
+	implementation("ca.pjer:logback-awslogs-appender:1.6.0")
+	implementation("com.amazonaws:aws-java-sdk-logs:1.12.+")
 	runtimeOnly("org.postgresql:postgresql")
 	runtimeOnly("org.postgresql:r2dbc-postgresql")
 

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="CLOUDWATCH" class="ca.pjer.logback.AwsLogsAppender">
+        <layout>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </layout>
+        <logGroupName>/a-and-i/auth</logGroupName>
+        <logStreamUuidPrefix>auth-</logStreamUuidPrefix>
+        <logRegion>ap-northeast-2</logRegion>
+        <maxBatchLogEvents>50</maxBatchLogEvents>
+        <maxFlushTimeMillis>30000</maxFlushTimeMillis>
+        <maxBlockTimeMillis>5000</maxBlockTimeMillis>
+    </appender>
+
+    <springProfile name="local">
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
+
+    <springProfile name="prod">
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="CLOUDWATCH"/>
+        </root>
+    </springProfile>
+
+</configuration>


### PR DESCRIPTION
## 변경 내용 (What)
- ca.pjer:logback-awslogs-appender, com.amazonaws:aws-java-sdk-logs 의존성 추가                                                                                  
- logback-spring.xml 생성 — local 프로파일은 콘솔만, prod 프로파일은 콘솔 + CloudWatch 동시 출력                                                                 
- CloudWatch 로그 그룹: /a-and-i/auth, 스트림 prefix: auth-, 리전: ap-northeast-2

## 확인 방법 (How to check)
- prod 프로파일로 서버 실행 후 AWS CloudWatch 콘솔에서 /a-and-i/auth 로그 그룹에 로그가 수집되는지 확인                                                          
- local 프로파일에서는 CloudWatch 연동 없이 콘솔 로그만 출력되는지 확인

## 체크리스트
- [ x ] PR 목적이 하나입니다 (한 PR = 한 목적)
- [ x ] 변경 범위를 최소화했습니다
- [ x ] 문서/가이드가 필요하면 함께 업데이트했습니다
- [x] (선택) 스크린샷/로그/요청·응답 예시를 첨부했습니다

## 참고 (선택)
- 관련 이슈: 
- 기타 공유할 내용: EC2에 CloudWatch 권한을 가진 IAM 역할이 부착되어 있어 별도 AWS 키 설정 없이 동작합니다
