### PR TITLE
feat: refresh 응답 관련 보안 이슈 대응

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,214 @@ docker compose up --build
 - Auth API: `http://localhost:8080`
 - Swagger UI: `http://localhost:8080/swagger-ui.html`
 
+## OpenAPI / Swagger
+- Swagger UI: `/swagger-ui.html`
+- 통합 문서: `/v3/api-docs`
+- v1 문서: `/v3/api-docs/v1`
+- v2 문서: `/v3/api-docs/v2`
+
+게이트웨이 뒤에서 운영할 경우 아래 경로가 함께 라우팅되어야 Swagger UI에서 v1/v2 드롭다운이 정상 동작합니다.
+- `/swagger-ui.html`
+- `/swagger-ui/**`
+- `/v3/api-docs/**`
+
+## API Versioning
+- 기존 v1 API는 유지합니다.
+- 신규 A&I 규약 대응 API는 `/v2/**`로 제공합니다.
+- 원칙:
+  - v1 요청/응답 스펙은 변경하지 않음
+  - v2는 Controller/DTO/응답 래퍼/예외 응답/헤더 처리 계층 중심으로 분리
+  - Service/도메인/Repository 로직은 최대한 재사용
+
+## A&I v2 Contract Summary
+
+### Common Response Envelope
+v2 응답은 아래 구조를 따릅니다.
+
+```json
+{
+  "success": true,
+  "data": {},
+  "error": null,
+  "timestamp": "2026-04-09T12:00:00Z"
+}
+```
+
+실패 시:
+
+```json
+{
+  "success": false,
+  "data": null,
+  "error": {
+    "code": 23101,
+    "message": "deviceOS header is required.",
+    "value": "MISSING_DEVICE_OS_HEADER",
+    "alert": "deviceOS header is required."
+  },
+  "timestamp": "2026-04-09T12:00:00Z"
+}
+```
+
+### Common Headers
+v2 API는 아래 헤더 체계를 사용합니다.
+- `deviceOS`: 필수
+- `timestamp`: 필수
+- `Authenticate`: 보호된 API에서 필수, 형식 `Bearer {accessToken}`
+- `salt`: 선택
+
+현재 서버는 `timestamp`를 아래 둘 다 허용합니다.
+- ISO-8601 문자열
+- epoch milliseconds
+
+### v2 Error Code Structure
+에러 코드는 5자리 정수 구조를 따릅니다.
+
+`[서비스 1자리][분류 1자리][상세 3자리]`
+
+서비스 코드:
+- `1`: Gateway
+- `2`: Auth
+- `3`: User
+- `4`: Report
+- `5`: Judge
+- `6`: Blog
+- `9`: Common
+
+분류 코드:
+- `0`: 일반
+- `1`: 인증
+- `2`: 인가
+- `3`: 검증
+- `4`: 비즈니스
+- `5`: 리소스 없음
+- `6`: 중복/충돌
+- `7`: 외부 시스템
+- `8`: 내부 오류
+
+### v2 Error Table in This Server
+현재 구현 기준으로 v2 오류 응답은 다음 원칙을 따릅니다.
+- `error.message`: 개발자용 메시지
+- `error.alert`: 유저용 메시지
+- 현재 구현상 대부분 `alert == message` 입니다.
+- 동일한 메시지라도 호출 경로에 따라 서비스 코드 prefix(`2xxxx`, `3xxxx`, `9xxxx`)가 달라질 수 있습니다.
+
+#### 1) 공통 / 보안 / 헤더 오류
+
+| 적용 경로 | 코드 | value | 개발자용 메시지 (`message`) | 유저용 메시지 (`alert`) |
+|---|---:|---|---|---|
+| `/v2/auth/**`, `/v2/activate`, `/v2/admin/invite-mail`, `/v2/admin/ping` | `23101` | `MISSING_DEVICE_OS_HEADER` | `deviceOS header is required.` | `deviceOS header is required.` |
+| `/v2/me/**`, `/v2/users/**`, `/v2/admin/users/**` | `33101` | `MISSING_DEVICE_OS_HEADER` | `deviceOS header is required.` | `deviceOS header is required.` |
+| `/v2/auth/**`, `/v2/activate`, `/v2/admin/invite-mail`, `/v2/admin/ping` | `23102` | `MISSING_TIMESTAMP_HEADER` | `timestamp header is required.` | `timestamp header is required.` |
+| `/v2/me/**`, `/v2/users/**`, `/v2/admin/users/**` | `33102` | `MISSING_TIMESTAMP_HEADER` | `timestamp header is required.` | `timestamp header is required.` |
+| `/v2/auth/**`, `/v2/activate`, `/v2/admin/invite-mail`, `/v2/admin/ping` | `23103` | `INVALID_TIMESTAMP_HEADER` | `timestamp header must be epoch milliseconds or ISO-8601.` | `timestamp header must be epoch milliseconds or ISO-8601.` |
+| `/v2/me/**`, `/v2/users/**`, `/v2/admin/users/**` | `33103` | `INVALID_TIMESTAMP_HEADER` | `timestamp header must be epoch milliseconds or ISO-8601.` | `timestamp header must be epoch milliseconds or ISO-8601.` |
+| 보호된 Auth 계열 v2 경로 | `21101` | `UNAUTHORIZED` | `Authentication is required.` | `Authentication is required.` |
+| 보호된 User 계열 v2 경로 | `31101` | `UNAUTHORIZED` | `Authentication is required.` | `Authentication is required.` |
+| Auth 계열 v2 경로 인가 실패 | `22101` | `FORBIDDEN` | `You do not have permission to access this resource.` | `You do not have permission to access this resource.` |
+| User 계열 v2 경로 인가 실패 | `32101` | `FORBIDDEN` | `You do not have permission to access this resource.` | `You do not have permission to access this resource.` |
+
+#### 2) Auth / Token / Activation 오류
+
+| 적용 경로 | 코드 | value | 개발자용 메시지 (`message`) | 유저용 메시지 (`alert`) |
+|---|---:|---|---|---|
+| `/v2/auth/login`, `/v2/me/password` | `21101` / `31101` | `UNAUTHORIZED` | `Invalid username or password.` | `Invalid username or password.` |
+| `/v2/auth/refresh` | `21101` | `UNAUTHORIZED` | `Refresh token is logged out.` | `Refresh token is logged out.` |
+| `/v2/activate` | `21101` | `UNAUTHORIZED` | `Invalid or expired invite token.` | `Invalid or expired invite token.` |
+| `/v2/activate` | `23101` | `INVALID_REQUEST` | `Requested username is not available.` | `Requested username is not available.` |
+| `/v2/auth/refresh`, `/v2/me/**`, `/v2/admin/**` 보호 경로 | `21101` / `31101` | `UNAUTHORIZED` | `Invalid token format.` | `Invalid token format.` |
+| `/v2/auth/refresh`, `/v2/me/**`, `/v2/admin/**` 보호 경로 | `21101` / `31101` | `UNAUTHORIZED` | `Invalid token signature.` | `Invalid token signature.` |
+| `/v2/auth/refresh`, `/v2/me/**`, `/v2/admin/**` 보호 경로 | `21101` / `31101` | `UNAUTHORIZED` | `Invalid token issuer.` | `Invalid token issuer.` |
+| `/v2/auth/refresh`, `/v2/me/**`, `/v2/admin/**` 보호 경로 | `21101` / `31101` | `UNAUTHORIZED` | `Invalid token audience.` | `Invalid token audience.` |
+| `/v2/auth/refresh`, `/v2/me/**`, `/v2/admin/**` 보호 경로 | `21101` / `31101` | `UNAUTHORIZED` | `Unexpected token type.` | `Unexpected token type.` |
+| `/v2/auth/refresh`, `/v2/me/**`, `/v2/admin/**` 보호 경로 | `21101` / `31101` | `UNAUTHORIZED` | `Missing token expiration.` | `Missing token expiration.` |
+| `/v2/auth/refresh`, `/v2/me/**`, `/v2/admin/**` 보호 경로 | `21101` / `31101` | `UNAUTHORIZED` | `Token is expired.` | `Token is expired.` |
+| `/v2/auth/refresh`, `/v2/me/**`, `/v2/admin/**` 보호 경로 | `21101` / `31101` | `UNAUTHORIZED` | `Missing token issue time.` | `Missing token issue time.` |
+| `/v2/auth/refresh`, `/v2/me/**`, `/v2/admin/**` 보호 경로 | `21101` / `31101` | `UNAUTHORIZED` | `Token issue time is invalid.` | `Token issue time is invalid.` |
+| `/v2/auth/refresh`, `/v2/me/**`, `/v2/admin/**` 보호 경로 | `21101` / `31101` | `UNAUTHORIZED` | `Invalid token subject.` | `Invalid token subject.` |
+| `/v2/auth/refresh`, `/v2/me/**`, `/v2/admin/**` 보호 경로 | `21101` / `31101` | `UNAUTHORIZED` | `Missing username claim.` | `Missing username claim.` |
+| `/v2/auth/refresh`, `/v2/me/**`, `/v2/admin/**` 보호 경로 | `21101` / `31101` | `UNAUTHORIZED` | `Invalid role claim.` | `Invalid role claim.` |
+| `/v2/auth/refresh`, `/v2/me/**`, `/v2/admin/**` 보호 경로 | `21101` / `31101` | `UNAUTHORIZED` | `Missing token jti.` | `Missing token jti.` |
+| `/v2/auth/refresh`, `/v2/me/**`, `/v2/admin/**` 보호 경로 | `21101` / `31101` | `UNAUTHORIZED` | `Invalid token type claim.` | `Invalid token type claim.` |
+| `/v2/auth/**` | `28101` | `INTERNAL_SERVER_ERROR` | `Failed to sign token.` | `Failed to sign token.` |
+
+#### 3) User / Profile 오류
+
+| 적용 경로 | 코드 | value | 개발자용 메시지 (`message`) | 유저용 메시지 (`alert`) |
+|---|---:|---|---|---|
+| `/v2/me`, `/v2/me/profile-image/upload-url`, `/v2/users/lookup` | `35101` | `NOT_FOUND` | `User not found.` | `User not found.` |
+| `/v2/me` | `33101` | `INVALID_REQUEST` | `At least one profile field is required.` | `At least one profile field is required.` |
+| `/v2/me` | `33101` | `INVALID_REQUEST` | `profileImage and profileImageUrl cannot be used together.` | `profileImage and profileImageUrl cannot be used together.` |
+| `/v2/me` | `33101` | `INVALID_REQUEST` | `nickname must not be blank.` | `nickname must not be blank.` |
+| `/v2/me` | `33101` | `INVALID_REQUEST` | `nickname must be a text form field.` | `nickname must be a text form field.` |
+| `/v2/me` | `33101` | `INVALID_REQUEST` | `profileImageUrl must not be blank.` | `profileImageUrl must not be blank.` |
+| `/v2/me` | `33101` | `INVALID_REQUEST` | `profileImageUrl must be a valid https URL.` | `profileImageUrl must be a valid https URL.` |
+| `/v2/me` | `33101` | `INVALID_REQUEST` | `profileImageUrl host is not allowed.` | `profileImageUrl host is not allowed.` |
+| `/v2/me` | `33101` | `INVALID_REQUEST` | `profileImage content type is required.` | `profileImage content type is required.` |
+| `/v2/me`, `/v2/me/profile-image/upload-url` | `33101` | `INVALID_REQUEST` | `Unsupported profile image content type.` | `Unsupported profile image content type.` |
+| `/v2/me` | `33101` | `INVALID_REQUEST` | `profileImage must not be empty.` | `profileImage must not be empty.` |
+| `/v2/me`, `/v2/me/profile-image/upload-url` | `32101` | `FORBIDDEN` | `Profile image upload is disabled.` | `Profile image upload is disabled.` |
+| `/v2/me`, `/v2/me/profile-image/upload-url` | `38101` | `INTERNAL_SERVER_ERROR` | `Profile image bucket is not configured.` | `Profile image bucket is not configured.` |
+| `/v2/users/lookup` | `33101` | `INVALID_REQUEST` | `Invalid user code format.` | `Invalid user code format.` |
+| `/v2/users/lookup` | `33101` | `INVALID_REQUEST` | `cohort must be between 0 and 9.` | `cohort must be between 0 and 9.` |
+| `/v2/users/lookup` | `38101` | `INTERNAL_SERVER_ERROR` | `cohort order is out of supported range.` | `cohort order is out of supported range.` |
+
+#### 4) Admin 오류
+
+| 적용 경로 | 코드 | value | 개발자용 메시지 (`message`) | 유저용 메시지 (`alert`) |
+|---|---:|---|---|---|
+| `/v2/admin/users/{id}/role` | `32101` | `FORBIDDEN` | `Admin cannot change own role.` | `Admin cannot change own role.` |
+| `/v2/admin/users/{id}` | `32101` | `FORBIDDEN` | `Admin cannot update own account via admin endpoint.` | `Admin cannot update own account via admin endpoint.` |
+| `/v2/admin/users/{id}` | `32101` | `FORBIDDEN` | `Admin cannot delete own account.` | `Admin cannot delete own account.` |
+| `/v2/admin/users`, `/v2/admin/users/{id}`, `/v2/admin/users/{id}/role` | `35101` | `NOT_FOUND` | `User not found.` | `User not found.` |
+| `/v2/admin/users`, `/v2/admin/invite-mail` | `33101` / `23101` | `INVALID_REQUEST` | `At least one email is required.` | `At least one email is required.` |
+| `/v2/admin/users/{id}` | `33101` | `INVALID_REQUEST` | `At least one updatable field is required.` | `At least one updatable field is required.` |
+| `/v2/admin/users/{id}` | `33101` | `INVALID_REQUEST` | `nickname must not be blank.` | `nickname must not be blank.` |
+| `/v2/admin/invite-mail` | `23101` | `INVALID_REQUEST` | `Requested cohortOrder is already in use.` | `Requested cohortOrder is already in use.` |
+| `/v2/admin/invite-mail` | `23101` | `INVALID_REQUEST` | `cohort must be greater than or equal to 0.` | `cohort must be greater than or equal to 0.` |
+| `/v2/admin/invite-mail` | `23101` | `INVALID_REQUEST` | `cohort must be between 0 and 9.` | `cohort must be between 0 and 9.` |
+| `/v2/admin/invite-mail` | `23101` | `INVALID_REQUEST` | `cohortOrder must be greater than or equal to 0.` | `cohortOrder must be greater than or equal to 0.` |
+| `/v2/admin/users`, `/v2/admin/users/{id}`, `/v2/admin/users/{id}/role` | `38101` | `INTERNAL_SERVER_ERROR` | `Failed to allocate a unique public code.` | `Failed to allocate a unique public code.` |
+| `/v2/admin/users`, `/v2/admin/invite-mail` | `28101` / `38101` | `INTERNAL_SERVER_ERROR` | `Failed to allocate a valid sequence.` | `Failed to allocate a valid sequence.` |
+| `/v2/admin/invite-mail` | `28101` | `INTERNAL_SERVER_ERROR` | `Failed to issue invite link.` | `Failed to issue invite link.` |
+| `/v2/admin/invite-mail` | `28101` | `INTERNAL_SERVER_ERROR` | `Failed to issue invite expiration.` | `Failed to issue invite expiration.` |
+| `/v2/admin/invite-mail` | `28101` | `INTERNAL_SERVER_ERROR` | `Failed to send invite email.` | `Failed to send invite email.` |
+| `/v2/admin/invite-mail` | `28101` | `INTERNAL_SERVER_ERROR` | `Mail sender is not configured.` | `Mail sender is not configured.` |
+| `/v2/admin/invite-mail` | `28101` | `INTERNAL_SERVER_ERROR` | `Mail from address is not configured.` | `Mail from address is not configured.` |
+
+#### 5) Bean Validation / 요청 파싱 오류
+
+| 적용 경로 | 코드 | value | 개발자용 메시지 (`message`) | 유저용 메시지 (`alert`) |
+|---|---:|---|---|---|
+| Auth 계열 v2 경로 | `23101` | `INVALID_REQUEST` | 첫 번째 DTO validation 메시지 또는 `Invalid request.` | 동일 |
+| User 계열 v2 경로 | `33101` | `INVALID_REQUEST` | 첫 번째 DTO validation 메시지 또는 `Invalid request.` | 동일 |
+| Common 계열 v2 경로 | `93101` | `INVALID_REQUEST` | 첫 번째 DTO validation 메시지 또는 `Invalid request.` | 동일 |
+
+예시 validation 메시지:
+- `username is required`
+- `password is required`
+- `newPassword length must be between 12 and 128`
+- `emails must not be empty`
+- `올바르지 않은 아이디 형식입니다. 영대소문자숫자만 사용가능합니다.`
+
+#### 6) 참고 사항
+- `/v2/admin/users/**` 는 현재 구현에서 User 서비스 코드(`3xxxx`)로 매핑됩니다.
+- `/v2/admin/invite-mail`, `/v2/admin/ping` 는 현재 구현에서 Auth 서비스 코드(`2xxxx`)로 매핑됩니다.
+- Admin 전용 서비스 코드가 따로 있는 것은 아니며, 현재는 경로 기반 매핑 결과를 그대로 사용합니다.
+- 향후 `value` 와 `alert` 를 세분화하려면 `AppException` 생성 시 개별 값을 명시하도록 확장하는 것이 좋습니다.
+
+### Current v2 Auth Header Behavior
+- 공개 API
+  - `/v2/auth/**`
+  - `/v2/activate`
+  - `/v2/ping/**`
+- 보호 API
+  - `/v2/me/**`
+  - `/v2/users/lookup`
+  - `/v2/admin/**`
+
+보호 API는 `Authenticate: Bearer {accessToken}` 헤더가 필요합니다.
+
 ## Profile Image Upload (S3 Presigned URL)
 - `POST /v1/me`를 `multipart/form-data`로 호출해 `nickname` + `profileImage`를 한 번에 처리
   - 서버가 이미지를 S3에 업로드한 뒤 사용자 프로필을 갱신

--- a/src/main/kotlin/com/aandiclub/auth/admin/web/v2/V2AdminController.kt
+++ b/src/main/kotlin/com/aandiclub/auth/admin/web/v2/V2AdminController.kt
@@ -40,7 +40,7 @@ import reactor.core.publisher.Mono
 import java.util.UUID
 
 @RestController
-@RequestMapping("/api/v2/admin")
+@RequestMapping("/v2/admin")
 @Validated
 class V2AdminController(
 	private val adminService: AdminService,

--- a/src/main/kotlin/com/aandiclub/auth/auth/web/dto/v2/AuthV2Dtos.kt
+++ b/src/main/kotlin/com/aandiclub/auth/auth/web/dto/v2/AuthV2Dtos.kt
@@ -14,13 +14,11 @@ data class V2LoginRequest(
 )
 
 data class V2RefreshRequest(
-	@field:NotBlank(message = "refreshToken is required")
-	val refreshToken: String,
+	val refreshToken: String? = null,
 )
 
 data class V2LogoutRequest(
-	@field:NotBlank(message = "refreshToken is required")
-	val refreshToken: String,
+	val refreshToken: String? = null,
 )
 
 data class V2ActivateRequest(
@@ -39,7 +37,7 @@ data class V2ActivateRequest(
 
 data class V2LoginResponse(
 	val accessToken: String,
-	val refreshToken: String,
+	val refreshToken: String?,
 	val expiresIn: Long,
 	val tokenType: String,
 	val forcePasswordChange: Boolean,

--- a/src/main/kotlin/com/aandiclub/auth/auth/web/v2/V2AuthController.kt
+++ b/src/main/kotlin/com/aandiclub/auth/auth/web/v2/V2AuthController.kt
@@ -25,7 +25,7 @@ import org.springframework.web.bind.annotation.RestController
 import reactor.core.publisher.Mono
 
 @RestController
-@RequestMapping("/api/v2/auth")
+@RequestMapping("/v2/auth")
 @Validated
 class V2AuthController(
 	private val authService: AuthService,
@@ -62,7 +62,7 @@ class V2AuthController(
 }
 
 @RestController
-@RequestMapping("/api/v2")
+@RequestMapping("/v2")
 @Validated
 class V2ActivationController(
 	private val authService: AuthService,

--- a/src/main/kotlin/com/aandiclub/auth/auth/web/v2/V2AuthController.kt
+++ b/src/main/kotlin/com/aandiclub/auth/auth/web/v2/V2AuthController.kt
@@ -6,49 +6,111 @@ import com.aandiclub.auth.auth.web.dto.LoginRequest
 import com.aandiclub.auth.auth.web.dto.LoginResponse
 import com.aandiclub.auth.auth.web.dto.LogoutRequest
 import com.aandiclub.auth.auth.web.dto.RefreshRequest
-import com.aandiclub.auth.auth.web.dto.v2.V2ActivateRequest
-import com.aandiclub.auth.auth.web.dto.v2.V2ActivateResponse
-import com.aandiclub.auth.auth.web.dto.v2.V2LoginRequest
-import com.aandiclub.auth.auth.web.dto.v2.V2LoginResponse
-import com.aandiclub.auth.auth.web.dto.v2.V2LoginUser
-import com.aandiclub.auth.auth.web.dto.v2.V2LogoutRequest
-import com.aandiclub.auth.auth.web.dto.v2.V2LogoutResponse
-import com.aandiclub.auth.auth.web.dto.v2.V2RefreshRequest
-import com.aandiclub.auth.auth.web.dto.v2.V2RefreshResponse
+import com.aandiclub.auth.auth.web.dto.v2.*
 import com.aandiclub.auth.common.api.v2.V2ApiResponse
+import com.aandiclub.auth.common.error.AppException
+import com.aandiclub.auth.common.error.ErrorCode
+import com.aandiclub.auth.common.web.v2.V2HeaderValidationWebFilter
+import com.aandiclub.auth.security.jwt.JwtProperties
+import com.aandiclub.auth.security.service.JwtService
 import jakarta.validation.Valid
+import org.springframework.http.ResponseCookie
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.server.ServerWebExchange
 import reactor.core.publisher.Mono
+import java.time.Duration
 
 @RestController
 @RequestMapping("/v2/auth")
 @Validated
 class V2AuthController(
 	private val authService: AuthService,
+	private val jwtService: JwtService,
+	private val jwtProperties: JwtProperties,
 ) {
 	@PostMapping("/login")
-	fun login(@Valid @RequestBody request: V2LoginRequest): Mono<V2ApiResponse<V2LoginResponse>> =
-		authService.login(LoginRequest(username = request.username, password = request.password))
-			.map { V2ApiResponse.success(it.toV2()) }
+	fun login(
+		@Valid @RequestBody request: V2LoginRequest,
+		exchange: ServerWebExchange,
+	): Mono<V2ApiResponse<V2LoginResponse>> {
+		val isWeb = isWebClient(exchange)
+		return authService.login(LoginRequest(username = request.username, password = request.password))
+			.map { response ->
+				val refreshToken = handleRefreshToken(exchange, response.refreshToken, isWeb)
+				V2ApiResponse.success(response.toV2(refreshToken))
+			}
+	}
 
 	@PostMapping("/refresh")
-	fun refresh(@Valid @RequestBody request: V2RefreshRequest): Mono<V2ApiResponse<V2RefreshResponse>> =
-		authService.refresh(RefreshRequest(refreshToken = request.refreshToken))
+	fun refresh(
+		@Valid @RequestBody request: V2RefreshRequest,
+		exchange: ServerWebExchange,
+	): Mono<V2ApiResponse<V2RefreshResponse>> {
+		val refreshToken = request.refreshToken
+			?: exchange.request.cookies.getFirst(REFRESH_TOKEN_COOKIE)?.value
+			?: throw AppException(ErrorCode.UNAUTHORIZED, "Refresh token is missing.")
+
+		return authService.refresh(RefreshRequest(refreshToken = refreshToken))
 			.map { V2ApiResponse.success(V2RefreshResponse(accessToken = it.accessToken, expiresIn = it.expiresIn)) }
+	}
 
 	@PostMapping("/logout")
-	fun logout(@Valid @RequestBody request: V2LogoutRequest): Mono<V2ApiResponse<V2LogoutResponse>> =
-		authService.logout(LogoutRequest(refreshToken = request.refreshToken))
-			.map { V2ApiResponse.success(V2LogoutResponse(loggedOut = it.success)) }
+	fun logout(
+		@Valid @RequestBody request: V2LogoutRequest,
+		exchange: ServerWebExchange,
+	): Mono<V2ApiResponse<V2LogoutResponse>> {
+		val isWeb = isWebClient(exchange)
+		val refreshToken = request.refreshToken
+			?: exchange.request.cookies.getFirst(REFRESH_TOKEN_COOKIE)?.value
+			?: return Mono.just(V2ApiResponse.success(V2LogoutResponse(loggedOut = true)))
 
-	private fun LoginResponse.toV2(): V2LoginResponse =
+		return authService.logout(LogoutRequest(refreshToken = refreshToken))
+			.doOnSuccess { if (isWeb) clearRefreshTokenCookie(exchange) }
+			.map { V2ApiResponse.success(V2LogoutResponse(loggedOut = it.success)) }
+	}
+
+	private fun isWebClient(exchange: ServerWebExchange): Boolean =
+		exchange.request.headers.getFirst(V2HeaderValidationWebFilter.DEVICE_OS_HEADER)
+			?.equals("WEB", ignoreCase = true) == true
+
+	private fun handleRefreshToken(
+		exchange: ServerWebExchange,
+		refreshToken: String,
+		isWeb: Boolean,
+	): String? {
+		if (isWeb) {
+			val cookie = ResponseCookie.from(REFRESH_TOKEN_COOKIE, refreshToken)
+				.httpOnly(true)
+				.secure(true)
+				.path("/")
+				.maxAge(Duration.ofSeconds(jwtProperties.refreshTokenExpSeconds))
+				.sameSite("Strict")
+				.build()
+			exchange.response.addCookie(cookie)
+			return null
+		}
+		return refreshToken
+	}
+
+	private fun clearRefreshTokenCookie(exchange: ServerWebExchange) {
+		val cookie = ResponseCookie.from(REFRESH_TOKEN_COOKIE, "")
+			.httpOnly(true)
+			.secure(true)
+			.path("/")
+			.maxAge(0)
+			.sameSite("Strict")
+			.build()
+		exchange.response.addCookie(cookie)
+	}
+
+	private fun LoginResponse.toV2(v2RefreshToken: String?): V2LoginResponse =
 		V2LoginResponse(
 			accessToken = accessToken,
-			refreshToken = refreshToken,
+			refreshToken = v2RefreshToken,
 			expiresIn = expiresIn,
 			tokenType = tokenType,
 			forcePasswordChange = forcePasswordChange,
@@ -59,6 +121,10 @@ class V2AuthController(
 				publicCode = user.publicCode,
 			),
 		)
+
+	companion object {
+		private const val REFRESH_TOKEN_COOKIE = "refresh_token"
+	}
 }
 
 @RestController

--- a/src/main/kotlin/com/aandiclub/auth/common/config/OpenApiConfig.kt
+++ b/src/main/kotlin/com/aandiclub/auth/common/config/OpenApiConfig.kt
@@ -59,7 +59,7 @@ class OpenApiConfig(
 	fun v2GroupedOpenApi(): GroupedOpenApi =
 		GroupedOpenApi.builder()
 			.group("v2")
-			.pathsToMatch("/api/v2/**")
+			.pathsToMatch("/v2/**")
 			.addOpenApiCustomizer(versionInfoCustomizer(version = "v2"))
 			.addOperationCustomizer(v2OperationCustomizer())
 			.build()
@@ -190,7 +190,7 @@ class OpenApiConfig(
 		path.startsWith("/v1/me") || path == "/v1/users/lookup" || path.startsWith("/v1/admin")
 
 	private fun isProtectedV2Path(path: String): Boolean =
-		path.startsWith("/api/v2/me") || path == "/api/v2/users/lookup" || path.startsWith("/api/v2/admin")
+		path.startsWith("/v2/me") || path == "/v2/users/lookup" || path.startsWith("/v2/admin")
 
 	companion object {
 		private const val BEARER_AUTH_SCHEME = "bearerAuth"

--- a/src/main/kotlin/com/aandiclub/auth/common/error/v2/V2ErrorFactory.kt
+++ b/src/main/kotlin/com/aandiclub/auth/common/error/v2/V2ErrorFactory.kt
@@ -33,9 +33,9 @@ class V2ErrorFactory {
 		V2ErrorSpec(V2ErrorCategory.INTERNAL, detail, value, message, message).toApiError(resolveService(path))
 
 	private fun resolveService(path: String): V2ServiceCode = when {
-		path.startsWith("/api/v2/me") || path.startsWith("/api/v2/users") -> V2ServiceCode.USER
-		path.startsWith("/api/v2/admin/users") -> V2ServiceCode.USER
-		path.startsWith("/api/v2/ping") -> V2ServiceCode.COMMON
+		path.startsWith("/v2/me") || path.startsWith("/v2/users") -> V2ServiceCode.USER
+		path.startsWith("/v2/admin/users") -> V2ServiceCode.USER
+		path.startsWith("/v2/ping") -> V2ServiceCode.COMMON
 		V2ApiPaths.isV2(path) -> V2ServiceCode.AUTH
 		else -> V2ServiceCode.COMMON
 	}

--- a/src/main/kotlin/com/aandiclub/auth/common/web/v2/V2ApiPaths.kt
+++ b/src/main/kotlin/com/aandiclub/auth/common/web/v2/V2ApiPaths.kt
@@ -1,7 +1,7 @@
 package com.aandiclub.auth.common.web.v2
 
 object V2ApiPaths {
-	private const val BASE_PATH = "/api/v2"
+	private const val BASE_PATH = "/v2"
 
 	fun isV2(path: String): Boolean = path == BASE_PATH || path.startsWith("$BASE_PATH/")
 }

--- a/src/main/kotlin/com/aandiclub/auth/common/web/v2/V2PingController.kt
+++ b/src/main/kotlin/com/aandiclub/auth/common/web/v2/V2PingController.kt
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-@RequestMapping("/api/v2/ping")
+@RequestMapping("/v2/ping")
 class V2PingController(
 	private val pingService: PingService,
 ) {

--- a/src/main/kotlin/com/aandiclub/auth/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/aandiclub/auth/security/config/SecurityConfig.kt
@@ -86,11 +86,11 @@ class SecurityConfig {
 				it.pathMatchers(HttpMethod.OPTIONS, "/**").permitAll()
 				it.pathMatchers(
 					"/v1/auth/**",
-					"/api/v2/auth/**",
+					"/v2/auth/**",
 					"/activate",
-					"/api/v2/activate",
+					"/v2/activate",
 					"/api/ping/**",
-					"/api/v2/ping/**",
+					"/v2/ping/**",
 					"/v3/api-docs/**",
 					"/swagger-ui.html",
 					"/swagger-ui/**",
@@ -98,11 +98,11 @@ class SecurityConfig {
 					"/actuator/info",
 				).permitAll()
 				it.pathMatchers("/v1/me", "/v1/me/**").hasAnyRole("USER", "ORGANIZER", "ADMIN")
-				it.pathMatchers("/api/v2/me", "/api/v2/me/**").hasAnyRole("USER", "ORGANIZER", "ADMIN")
+				it.pathMatchers("/v2/me", "/v2/me/**").hasAnyRole("USER", "ORGANIZER", "ADMIN")
 				it.pathMatchers(HttpMethod.GET, "/v1/users/lookup").hasAnyRole("ORGANIZER", "ADMIN")
-				it.pathMatchers(HttpMethod.GET, "/api/v2/users/lookup").hasAnyRole("ORGANIZER", "ADMIN")
+				it.pathMatchers(HttpMethod.GET, "/v2/users/lookup").hasAnyRole("ORGANIZER", "ADMIN")
 				it.pathMatchers("/v1/admin/**").hasRole("ADMIN")
-				it.pathMatchers("/api/v2/admin/**").hasRole("ADMIN")
+				it.pathMatchers("/v2/admin/**").hasRole("ADMIN")
 				it.anyExchange().authenticated()
 			}
 			.addFilterAt(v2HeaderValidationWebFilter, SecurityWebFiltersOrder.FIRST)

--- a/src/main/kotlin/com/aandiclub/auth/user/web/v2/V2UserController.kt
+++ b/src/main/kotlin/com/aandiclub/auth/user/web/v2/V2UserController.kt
@@ -36,7 +36,7 @@ import org.springframework.web.bind.annotation.RestController
 import reactor.core.publisher.Mono
 
 @RestController
-@RequestMapping("/api/v2/me")
+@RequestMapping("/v2/me")
 @Validated
 class V2UserController(
 	private val userService: UserService,
@@ -114,7 +114,7 @@ class V2UserController(
 }
 
 @RestController
-@RequestMapping("/api/v2/users")
+@RequestMapping("/v2/users")
 @Validated
 class V2UserLookupController(
 	private val userService: UserService,

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -46,7 +46,7 @@ app:
   cors:
     allowed-origins: ${APP_CORS_ALLOWED_ORIGINS:http://localhost:8080,http://127.0.0.1:8080,https://aandiclub.com,https://admin.aandiclub.com,https://auth.aandiclub.com,https://api.aandiclub.com}
     allowed-methods: ${APP_CORS_ALLOWED_METHODS:GET,POST,PUT,PATCH,DELETE,OPTIONS}
-    allowed-headers: ${APP_CORS_ALLOWED_HEADERS:Authorization,Content-Type,Accept,Origin,X-Requested-With}
+    allowed-headers: ${APP_CORS_ALLOWED_HEADERS:Authorization,Content-Type,Accept,Origin,X-Requested-With,deviceOS,timestamp}
     exposed-headers: ${APP_CORS_EXPOSED_HEADERS:}
     allow-credentials: ${APP_CORS_ALLOW_CREDENTIALS:true}
     max-age-seconds: ${APP_CORS_MAX_AGE_SECONDS:3600}

--- a/src/test/kotlin/com/aandiclub/auth/auth/web/V2AuthControllerTest.kt
+++ b/src/test/kotlin/com/aandiclub/auth/auth/web/V2AuthControllerTest.kt
@@ -22,7 +22,7 @@ class V2AuthControllerTest : FunSpec({
 		.controllerAdvice(V2ExceptionHandler(errorFactory))
 		.build()
 
-	test("POST /api/v2/auth/login returns v2 envelope") {
+	test("POST /v2/auth/login returns v2 envelope") {
 		every { authService.login(any()) } returns Mono.just(
 			LoginResponse(
 				accessToken = "access",
@@ -35,7 +35,7 @@ class V2AuthControllerTest : FunSpec({
 		)
 
 		webTestClient.post()
-			.uri("/api/v2/auth/login")
+			.uri("/v2/auth/login")
 			.contentType(MediaType.APPLICATION_JSON)
 			.bodyValue("""{"username":"user_01","password":"password"}""")
 			.exchange()

--- a/src/test/kotlin/com/aandiclub/auth/auth/web/V2AuthControllerTest.kt
+++ b/src/test/kotlin/com/aandiclub/auth/auth/web/V2AuthControllerTest.kt
@@ -6,6 +6,8 @@ import com.aandiclub.auth.auth.web.dto.LoginUser
 import com.aandiclub.auth.auth.web.v2.V2AuthController
 import com.aandiclub.auth.common.error.v2.V2ErrorFactory
 import com.aandiclub.auth.common.error.v2.V2ExceptionHandler
+import com.aandiclub.auth.security.jwt.JwtProperties
+import com.aandiclub.auth.security.service.JwtService
 import com.aandiclub.auth.user.domain.UserRole
 import io.kotest.core.spec.style.FunSpec
 import io.mockk.every
@@ -17,12 +19,22 @@ import java.util.UUID
 
 class V2AuthControllerTest : FunSpec({
 	val authService = mockk<AuthService>()
+	val jwtService = mockk<JwtService>()
+	val jwtProperties = JwtProperties(
+		issuer = "issuer",
+		audience = "audience",
+		secret = "secret",
+		accessTokenExpSeconds = 3600,
+		refreshTokenExpSeconds = 86400,
+		clockSkewSeconds = 30,
+	)
 	val errorFactory = V2ErrorFactory()
-	val webTestClient = WebTestClient.bindToController(V2AuthController(authService))
+	val webTestClient = WebTestClient.bindToController(V2AuthController(authService, jwtService, jwtProperties))
 		.controllerAdvice(V2ExceptionHandler(errorFactory))
 		.build()
 
-	test("POST /v2/auth/login returns v2 envelope") {
+	test("POST /v2/auth/login returns v2 envelope and sets cookie for web") {
+		val userId = UUID.randomUUID()
 		every { authService.login(any()) } returns Mono.just(
 			LoginResponse(
 				accessToken = "access",
@@ -30,20 +42,49 @@ class V2AuthControllerTest : FunSpec({
 				expiresIn = 3600,
 				tokenType = "Bearer",
 				forcePasswordChange = false,
-				user = LoginUser(UUID.randomUUID(), "user_01", UserRole.USER, "#NO001"),
+				user = LoginUser(userId, "user_01", UserRole.USER, "#NO001"),
 			),
 		)
 
 		webTestClient.post()
 			.uri("/v2/auth/login")
+			.header("deviceOS", "WEB")
 			.contentType(MediaType.APPLICATION_JSON)
 			.bodyValue("""{"username":"user_01","password":"password"}""")
 			.exchange()
 			.expectStatus().isOk
+			.expectCookie().valueEquals("refresh_token", "refresh")
 			.expectBody()
 			.jsonPath("$.success").isEqualTo(true)
 			.jsonPath("$.data.accessToken").isEqualTo("access")
+			.jsonPath("$.data.refreshToken").isEqualTo(null)
 			.jsonPath("$.data.user.username").isEqualTo("user_01")
-			.jsonPath("$.error").doesNotExist()
+	}
+
+	test("POST /v2/auth/login returns v2 envelope and token in body for non-web") {
+		val userId = UUID.randomUUID()
+		every { authService.login(any()) } returns Mono.just(
+			LoginResponse(
+				accessToken = "access",
+				refreshToken = "refresh",
+				expiresIn = 3600,
+				tokenType = "Bearer",
+				forcePasswordChange = false,
+				user = LoginUser(userId, "user_01", UserRole.USER, "#NO001"),
+			),
+		)
+
+		webTestClient.post()
+			.uri("/v2/auth/login")
+			.header("deviceOS", "ANDROID")
+			.contentType(MediaType.APPLICATION_JSON)
+			.bodyValue("""{"username":"user_01","password":"password"}""")
+			.exchange()
+			.expectStatus().isOk
+			.expectCookie().doesNotExist("refresh_token")
+			.expectBody()
+			.jsonPath("$.success").isEqualTo(true)
+			.jsonPath("$.data.accessToken").isEqualTo("access")
+			.jsonPath("$.data.refreshToken").isEqualTo("refresh")
 	}
 })

--- a/src/test/kotlin/com/aandiclub/auth/common/OpenApiDocsTest.kt
+++ b/src/test/kotlin/com/aandiclub/auth/common/OpenApiDocsTest.kt
@@ -35,7 +35,7 @@ class OpenApiDocsTest : StringSpec() {
 				.expectBody()
 				.jsonPath("$.info.version").isEqualTo("v1")
 				.jsonPath("$.paths['/v1/me']").exists()
-				.jsonPath("$.paths['/api/v2/me']").doesNotExist()
+				.jsonPath("$.paths['/v2/me']").doesNotExist()
 				.jsonPath("$.components.securitySchemes.bearerAuth.scheme").isEqualTo("bearer")
 		}
 
@@ -46,11 +46,11 @@ class OpenApiDocsTest : StringSpec() {
 				.expectStatus().isOk
 				.expectBody()
 				.jsonPath("$.info.version").isEqualTo("v2")
-				.jsonPath("$.paths['/api/v2/me']").exists()
+				.jsonPath("$.paths['/v2/me']").exists()
 				.jsonPath("$.paths['/v1/me']").doesNotExist()
 				.jsonPath("$.components.securitySchemes.authenticateHeader.name").isEqualTo("Authenticate")
-				.jsonPath("$.paths['/api/v2/me'].get.security[0].authenticateHeader").isArray()
-		}
+				.jsonPath("$.paths['/v2/me'].get.security[0].authenticateHeader").isArray()
+	}
 
 		"GET /swagger-ui.html should be publicly accessible" {
 			webClient().get()

--- a/src/test/kotlin/com/aandiclub/auth/security/AuthorizationMatrixTest.kt
+++ b/src/test/kotlin/com/aandiclub/auth/security/AuthorizationMatrixTest.kt
@@ -92,9 +92,9 @@ class AuthorizationMatrixTest : StringSpec() {
 				.expectStatus().isUnauthorized
 		}
 
-		"GET /api/v2/me requires v2 headers" {
+		"GET /v2/me requires v2 headers" {
 			webClient().get()
-				.uri("/api/v2/me")
+				.uri("/v2/me")
 				.exchange()
 				.expectStatus().isBadRequest
 				.expectBody()
@@ -102,9 +102,9 @@ class AuthorizationMatrixTest : StringSpec() {
 				.jsonPath("$.error.code").isEqualTo(33101)
 		}
 
-		"GET /api/v2/me requires Authenticate header when v2 headers are present" {
+		"GET /v2/me requires Authenticate header when v2 headers are present" {
 			webClient().get()
-				.uri("/api/v2/me")
+				.uri("/v2/me")
 				.headers { headers ->
 					headers.add("deviceOS", "IOS")
 					headers.add("timestamp", Instant.now().toString())
@@ -133,13 +133,13 @@ class AuthorizationMatrixTest : StringSpec() {
 				.jsonPath("$.data.role").isEqualTo("USER")
 		}
 
-		"GET /api/v2/me allows USER role with Authenticate header" {
+		"GET /v2/me allows USER role with Authenticate header" {
 			val userId = UUID.randomUUID()
 			val username = "tester_user_v2"
 			insertUser(userId, username, UserRole.USER)
 			val token = accessToken(userId, username, UserRole.USER)
 			webClient().get()
-				.uri("/api/v2/me")
+				.uri("/v2/me")
 				.headers {
 					it.add("Authenticate", "Bearer $token")
 					it.add("deviceOS", "IOS")
@@ -268,10 +268,10 @@ class AuthorizationMatrixTest : StringSpec() {
 				.expectStatus().isForbidden
 		}
 
-		"GET /api/v2/admin/ping denies USER role with v2 error envelope" {
+		"GET /v2/admin/ping denies USER role with v2 error envelope" {
 			val token = accessToken(UUID.randomUUID(), "tester_user_denied_v2", UserRole.USER)
 			webClient().get()
-				.uri("/api/v2/admin/ping")
+				.uri("/v2/admin/ping")
 				.headers {
 					it.add("Authenticate", "Bearer $token")
 					it.add("deviceOS", "IOS")


### PR DESCRIPTION
## 변경 내용 (What)
- 기존 리프레시 토큰이 JSON 응답에 반환되어 발생할 수 있는 문제를 읽기 전용 쿠키 기반으로 변경했습니다.
 - V1 API 하위 호환성 유지: 기존 V1 API는 레거시 클라이언트를 위해 기존과 동일하게 JSON 바디를 통해 토큰을 전달하는 방식을 유지합니다.
 - V2 웹 전용 쿠키 정책 도입: V2AuthController에서 deviceOS: WEB 헤더 유무에 따른 분기 로직을 추가했습니다.
     - WEB: 보안 쿠키(HttpOnly, Secure, SameSite=Strict)를 통해 리프레시 토큰을 발행하고 응답 바디의 토큰 필드는 비웁니다.
     - 기타: 기존과 동일하게 응답 바디로 토큰을 전달합니다.
 - 로그아웃 쿠키 처리: 웹 클라이언트 로그아웃 시 Max-Age=0 설정을 통해 브라우저에 저장된 쿠키를 즉시 만료시키는 로직을 추가했습니다.
 - 테스트 코드 업데이트: V1(바디 검증) 및 V2(환경별 쿠키/바디 분기 검증)에 대한 유닛 테스트(V2AuthControllerTest 등)를 최신화했습니다.

## 확인 방법 (How to check)
- V2AuthControllerTest를 실행하여 deviceOS: WEB 헤더 유무에 따른 응답 형태(쿠키 vs 바디)를 확인합니다.
 - V1 로그인 API 호출 시 기존과 동일하게 JSON 바디에 리프레시 토큰이 포함되는지 확인합니다.
 - 로그아웃 API 호출 시 응답 헤더에 Set-Cookie: refresh_token=; Max-Age=0이 포함되는지 확인합니다.

## 체크리스트
- [x] PR 목적이 하나입니다 (한 PR = 한 목적)
- [x] 변경 범위를 최소화했습니다
- [x] 문서/가이드가 필요하면 함께 업데이트했습니다
- [ ] (선택) 스크린샷/로그/요청·응답 예시를 첨부했습니다

## 참고 (선택)
- 관련 이슈: #7
- 기타 공유할 내용: 서비스 레이어는 데이터 제공에만 집중하고, 전송 방식(쿠키/바디)은 컨트롤러가 결정하도록 책임을 분리했습니다.